### PR TITLE
Add missing translation for creds.edit

### DIFF
--- a/src/oxl_ansible_webui/aw/config/languages/en.py
+++ b/src/oxl_ansible_webui/aw/config/languages/en.py
@@ -185,6 +185,7 @@ EN = {
                                    'Make sure to select the "ECMAScript (Javascript)" flavor.',
 
     # credentials
+    'creds.edit': 'Edit Credentials',
     'creds.user': 'Personal',
     'creds.shared': 'Shared',
     'creds.new': 'New Credentials',

--- a/src/oxl_ansible_webui/aw/config/languages/es.py
+++ b/src/oxl_ansible_webui/aw/config/languages/es.py
@@ -182,6 +182,7 @@ ES = {
                                    'Asegúrate de seleccionar el "ECMAScript (Javascript)" sabor.',
 
     # credentials
+    'creds.edit': 'Editar Credencial',
     'creds.user': 'Personal',
     'creds.shared': 'Compartido',
     'creds.new': 'Nueva Credencial',


### PR DESCRIPTION
The Edit Credentials modal needed a localization for its title.